### PR TITLE
Change xcopy command to support terminals in other languages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ var fsPath = {
               callback(err);
             } else {
               if (that._win32) {
-                cmd = 'echo da|xcopy /s /e "' + path.join(from, '*') + '" "' + dist + '"';
+                cmd = 'echo d|xcopy /s /e /y "' + path.join(from, '*') + '" "' + dist + '"';
               } else {
                 cmd = 'cp -f -R -p ' + path.join(from, '*').replace(/ /g, '\\ ') + ' ' + dist.replace(/ /g, '\\ ');
               }
@@ -66,7 +66,7 @@ var fsPath = {
           });
         } else if (stats.isFile()) {
           if (that._win32) {
-            cmd = 'echo fa|xcopy "' + from + '" "' + dist + '"';
+            cmd = 'echo f|xcopy /y "' + from + '" "' + dist + '"';
           } else {
             cmd = 'cp -f -p ' + from.replace(/ /g, '\\ ') + ' ' + dist.replace(/ /g, '\\ ');
           }


### PR DESCRIPTION
Hi,

I had a problem using this library in my computer, because my terminal is in portuguese and the confirm message when copying multiple files is different than in English.

> "Substituir C:\file? (sim/não/todos)"

instead of:

> "replace C:\file? (yes/no/all)" (or something like that)

I made a change to use the xcopy /Y argument instead inputing A hardcoded in echo command.